### PR TITLE
fix(ranking): use RPC to fetch rating ranking

### DIFF
--- a/src/components/Ranking/Ranking.tsx
+++ b/src/components/Ranking/Ranking.tsx
@@ -35,30 +35,16 @@ export function Ranking() {
 
       switch (activeTab) {
         case 'rating': {
-          const { data: profiles } = await supabase
-            .from('profiles')
-            .select('id, username, rating')
-            .order('rating', { ascending: false })
-            .limit(100);
-          if (profiles && profiles.length > 0) {
-            const userIds = profiles.map((p) => p.id);
-            // Fetch match_history for these users to count rated plays
-            const { data: matches } = await supabase
-              .from('match_history')
-              .select('user_id')
-              .in('user_id', userIds)
-              .neq('status', 'pending');
-            const countMap = new Map<string, number>();
-            matches?.forEach((m) => {
-              countMap.set(m.user_id, (countMap.get(m.user_id) || 0) + 1);
-            });
-            data = profiles.map((p) => ({
-              id: p.id,
-              username: p.username || '???',
-              value: Math.round(p.rating),
-              extra: String(countMap.get(p.id) || 0),
-            }));
-          }
+          const { data: results } = await supabase.rpc('get_rating_ranking');
+          data =
+            results?.map(
+              (r: { id: string; username: string; rating: number; play_count: number }) => ({
+                id: r.id,
+                username: r.username || '???',
+                value: Math.round(r.rating),
+                extra: String(r.play_count),
+              }),
+            ) || [];
           break;
         }
         case 'survival_rated': {

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -240,6 +240,25 @@ begin
 end;
 $$ language plpgsql security definer;
 
+-- 7b2. Rating Ranking (with play count from match_history)
+create or replace function public.get_rating_ranking()
+returns table(id uuid, username text, rating double precision, play_count bigint) as $$
+begin
+  return query
+    select
+      p.id,
+      p.username,
+      p.rating,
+      count(mh.id) as play_count
+    from public.profiles p
+    left join public.match_history mh
+      on mh.user_id = p.id and mh.status != 'pending'
+    group by p.id, p.username, p.rating
+    order by p.rating desc
+    limit 100;
+end;
+$$ language plpgsql security definer;
+
 -- 7c. 問題を city_a_code + city_b_code で取得 (なければ作成)
 create or replace function public.get_or_create_question(
   p_city_a_code text,


### PR DESCRIPTION
This pull request streamlines the process of fetching the rating ranking with play counts by moving the logic from the frontend to a new database function. This improves performance, reduces frontend complexity, and ensures more accurate aggregation.

Ranking data retrieval improvements:

* Added the `get_rating_ranking` database function in `supabase/schema.sql` to efficiently fetch the top 100 profiles with their ratings and play counts, using a single query and aggregation.
* Updated the `Ranking` component in `src/components/Ranking/Ranking.tsx` to use the new `get_rating_ranking` function, removing redundant frontend logic for counting plays and simplifying the code.